### PR TITLE
Feature/shared dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ deployment_s3_object_path           : "" # Optional path
 deployment_s3_art_dir               : "{{ deployment_dir_base }}/artifacts"
 deployment_s3_aws_key_id            : "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
 deployment_s3_aws_secret_key        : "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
-deployment_s3_unarchive             : "ansible" 
+deployment_s3_unarchive             : "ansible"
 
 ## Deployment user/group and directroy
 deployment_user_manage              : False
@@ -61,12 +61,14 @@ deployment_user_manage_fingerprints : False
 deployment_user_fingerprints        :
     - "bitbucket.org,131.103.20.167 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw=="
     - "github.com,204.232.175.90 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
-# Create directory structure 
+# Create directory structure
 deployment_dir_structure            : True
 deployment_dir_base                 : "{{ deployment_user_home }}/{{ deployment_name }}"
 deployment_dir_work                 : "{{ deployment_dir_base }}/{{ deployment_version }}"
 deployment_dir_current              : "{{ deployment_dir_base }}/current"
 deployment_dir_version_file         : "{{ deployment_dir_base }}/{{ deployment_version_file_orginal }}"
+## Enable share dirs contains the linked_dirs which are symlinked into each release. This data persists across deployments and releases.
+deployment_shared_dir               : "{{ deployment_dir_base }}/shared"
 ## Extra directory that needs to be created (should be a list) i.e. ['/var/log/myapp','/opt/blaaa']
 deployment_extra_dirs               : 'none'
 ## Extra files that needs to be created (should be a list) i.e. ['/var/log/myapp.log','/somewhere/file.txt']
@@ -88,7 +90,7 @@ deployment_config_ini_vars_dest     : "{{ deployment_dir_base }}/{{ deployment_n
 # DotEnv variable
 deployment_config_dotenv_vars       : "none"
 deployment_config_dotenv_vars_dest  : "{{ deployment_dir_work }}/.env.php"
-## YAML vars config 
+## YAML vars config
 deployment_config_yaml_vars         : "none"
 ## FastCGI parm
 deployment_config_fastcgi_parm_vars : "none"
@@ -117,13 +119,17 @@ deployment_dependency_pip_args      :
                     chdir           : "{{ deployment_dir_work }}"
                     requirements    : "requirements.txt"
 
+# Should we keep old deployment
+deployment_delete_old               : False
+deployment_keep_last                : 3
+
 ## Post deployment managment
 deployment_post                     : False
-## List of comands to verify config is okay 
+## List of comands to verify config is okay
 #deployment_post_check_config       :
-#                          - "nginx -c /etc/nginx/nginx.conf -t" 
+#                          - "nginx -c /etc/nginx/nginx.conf -t"
 ## List of service to relead or restart
-# deployment_post_services            :   
+# deployment_post_services            :
 #                         - name      : nginx
 #                           state     : reload
 #                         - name      : php5-fpm

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ deployment_s3_object_path           : "" # Optional path
 deployment_s3_art_dir               : "{{ deployment_dir_base }}/artifacts"
 deployment_s3_aws_key_id            : "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
 deployment_s3_aws_secret_key        : "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
-deployment_s3_unarchive             : "ansible" 
+deployment_s3_unarchive             : "ansible"
 
 ## Deployment user/group and directroy
 deployment_user_manage              : False
@@ -36,12 +36,14 @@ deployment_user_manage_fingerprints : False
 deployment_user_fingerprints        :
     - "bitbucket.org,131.103.20.167 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw=="
     - "github.com,204.232.175.90 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
-# Create directory structure 
+# Create directory structure
 deployment_dir_structure            : True
 deployment_dir_base                 : "{{ deployment_user_home }}/{{ deployment_name }}"
 deployment_dir_work                 : "{{ deployment_dir_base }}/{{ deployment_version }}"
 deployment_dir_current              : "{{ deployment_dir_base }}/current"
 deployment_dir_version_file         : "{{ deployment_dir_base }}/{{ deployment_version_file_orginal }}"
+## Enable share dirs contains the linked_dirs which are symlinked into each release. This data persists across deployments and releases.
+deployment_shared_dir               : "{{ deployment_dir_base }}/shared"
 ## Extra directory that needs to be created (should be a list) i.e. ['/var/log/myapp','/opt/blaaa']
 deployment_extra_dirs               : 'none'
 ## Extra files that needs to be created (should be a list) i.e. ['/var/log/myapp.log','/somewhere/file.txt']
@@ -63,7 +65,7 @@ deployment_config_ini_vars_dest     : "{{ deployment_dir_base }}/{{ deployment_n
 # DotEnv variable
 deployment_config_dotenv_vars       : "none"
 deployment_config_dotenv_vars_dest  : "{{ deployment_dir_work }}/.env.php"
-## YAML vars config 
+## YAML vars config
 deployment_config_yaml_vars         : "none"
 ## FastCGI parm
 deployment_config_fastcgi_parm_vars : "none"
@@ -98,11 +100,11 @@ deployment_keep_last                : 3
 
 ## Post deployment managment
 deployment_post                     : False
-## List of comands to verify config is okay 
+## List of comands to verify config is okay
 #deployment_post_check_config       :
-#                          - "nginx -c /etc/nginx/nginx.conf -t" 
+#                          - "nginx -c /etc/nginx/nginx.conf -t"
 ## List of service to relead or restart
-# deployment_post_services            :   
+# deployment_post_services            :
 #                         - name      : nginx
 #                           state     : reload
 #                         - name      : php5-fpm

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,7 @@ deployment_dir_current              : "{{ deployment_dir_base }}/current"
 deployment_dir_version_file         : "{{ deployment_dir_base }}/{{ deployment_version_file_orginal }}"
 ## Enable share dirs contains the linked_dirs which are symlinked into each release. This data persists across deployments and releases.
 deployment_shared_dir               : "{{ deployment_dir_base }}/shared"
+deployment_shared_dirs              : 'none'
 ## Extra directory that needs to be created (should be a list) i.e. ['/var/log/myapp','/opt/blaaa']
 deployment_extra_dirs               : 'none'
 ## Extra files that needs to be created (should be a list) i.e. ['/var/log/myapp.log','/somewhere/file.txt']

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,7 +10,9 @@
     msg="Notifier restart app"
   changed_when: "{{ deployment_post }}"
   notify:
-    - check app config 
+    - check app config
+    - set failed
+    - execute post deployment scripts
     - set failed
     - restart app initd
     - set failed
@@ -24,13 +26,19 @@
   register: notify1
   when: deployment_post_check_config is defined
 
+- name: execute post deployment scripts
+  shell: "{{ item }}"
+  with_items: deployment_post_scripts
+  register: notify2
+  when: deployment_post_scripts is defined
+
 - name: restart app initd
   service:
     name="{{ item.name }}"
     state="{{ item.state | default('restarted') }}"
     enabled="{{ item.enabled | default(omit)}}"
   with_items: deployment_post_services
-  register: notify2
+  register: notify3
   when: deployment_post_services is defined and not notify_task_failed
 
 - name: wait for port to become ready
@@ -57,5 +65,3 @@
 #     msg="{{ deployment_artifact_name }} is not happy, {{deployment_http_check_url}} does not return expected content [{{deployment_http_check_expected_content}}]"
 #   register: payload
 #   when: deployment_http_check_expected_content is defined and deployment_http_check_expected_content not in webpage.content
-
-

--- a/tasks/current-version.yml
+++ b/tasks/current-version.yml
@@ -1,7 +1,32 @@
 ---
 
+- name: current version | Ensure shared dirs are present and ensure right permissions
+  file:
+    path="{{ deployment_shared_dir }}/{{ item }}"
+    owner="{{ deployment_user }}"
+    group="{{ deployment_group }}"
+    mode="{{ deployment_dir_perm }}"
+    state="directory"
+  when: deployment_shared_dirs != "none"
+  with_items: deployment_shared_dirs
+  notify:
+     - restart app
+
+- name: current version | Ensure shared dirs are present and ensure right permissions
+  file:
+    src="{{ deployment_shared_dir }}/{{ item }}"
+    dest="{{ deployment_dir_work }}/{{ item }}"
+    owner="{{ deployment_user }}"
+    group="{{ deployment_group }}"
+    mode="0755"
+    state="link"
+  when: deployment_shared_dirs != "none"
+  with_items: deployment_shared_dirs
+  notify:
+     - restart app
+
 - name: current version | Create current symlink
-  file: 
+  file:
     src="{{ deployment_dir_work }}"
     dest="{{ deployment_dir_current }}"
     owner="{{ deployment_user }}"


### PR DESCRIPTION
The shared functionality contains the linked dirs which are symlinked into each release. This data persists across deployments and releases. It should be used for things like static and persistent user storage handed over from one release to the next.

# How to use it?

```
deployment_shared_dirs                          :
                                                  - "web/uploads"
                                                  - "app/logs"
```