### PR TITLE
Add newrelic app name configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -178,6 +178,7 @@ deployment_slack_status_lookup:
 # NewRelic Notification
 deployment_notification_newrelic             : False   # by default no newrelic notification
 deployment_notification_newrelic_token       : XXXXXX  #  you should encrypt this value
+deployment_notification_newrelic_app_name    : "{{ deployment_name }}"
 deployment_notification_newrelic_description : "{{ inventory_hostname }}"
 deployment_notification_newrelic_user        : "{{ lookup('env','USER') }}"
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -81,7 +81,7 @@
 
 - name: Newrelic deployment notification
   newrelic_deployment: 
-    app_name="{{ deployment_name }}"
+    app_name="{{ deployment_notification_newrelic_app_name | default(deployment_name) }}"
     application_id="{{ deployment_notification_newrelic_application_id | default(omit) }}"
     changelog="{{ deployment_notification_newrelic_changelog | default(omit) }}"
     description="{{ deployment_notification_newrelic_description | default(omit) }}"


### PR DESCRIPTION
Stops newrelic from breaking if the app name is different on there.