### PR TITLE
Remove everything older than 14 days

### DIFF
--- a/library/delete_old_deployments.py
+++ b/library/delete_old_deployments.py
@@ -58,6 +58,11 @@ def main():
     deployment_dir      = module.params['path']
     keep_last           = module.params['keep_last']
     semantic_versioning = module.params['use_semantic_versioning']
+
+    # Remove everything older than 14 days
+    remove_old_stuff_cmd = 'find %s -maxdepth 1 -type d -mtime +14 -exec rm -rf "{}" \;'
+    exec_command(module, remove_old_stuff_cmd, deployment_dir)
+
     # keep deployment info
     list_deployment = []
     broken_deployment_dir = []


### PR DESCRIPTION
The `delete_old_deployments` script doesn't seem to work, I often have to run the following command for `api-v2`, `hq`, or `recipe-service`, because the disk is full:

```
sudo -u hellofresh find /hellofresh/src/api-v2/ -maxdepth 1 -type d -mtime +14 -exec rm -rvf "{}" \;
```

This PR removes everything older than 14 days. Because, frankly, who cares about ancient stuff?