### PR TITLE
Fix failing tests

### DIFF
--- a/test/fakeS3/tasks/main.yml
+++ b/test/fakeS3/tasks/main.yml
@@ -14,6 +14,7 @@
   gem:
     name=fakes3
     user_install=no
+    version="0.2.3"
 
 - name: Make fakes3 dir
   file: 


### PR DESCRIPTION
Latest (v0.2.4) release of fakes3 gem is fucked up, says 404 to all requests. To fix travis tests, locked gem version to 0.2.3.