### PR TITLE
Remove --pre from github3.py pip

### DIFF
--- a/tasks/resolver/github_releases.yml
+++ b/tasks/resolver/github_releases.yml
@@ -3,10 +3,8 @@
 - name: resolver | github-releases  | Install github stuff
   pip:
    name="{{ item.name }}"
-   extra_args="{{ item.extra_args | default(omit)}}"
   with_items:
      - name: github3.py
-       extra_args: "--pre"
      - name: semver
 
 - name: resolver | github-releases | Ensure artifact directory exists

--- a/test/integration/ghrelease/release_type.yml
+++ b/test/integration/ghrelease/release_type.yml
@@ -14,7 +14,6 @@
        extra_args="{{ item.extra_args | default(omit)}}"
       with_items:
          - name: github3.py
-           extra_args: "--pre"
          - name: semver
          - name: uritemplate
 

--- a/test/integration/ghrelease/source.yml
+++ b/test/integration/ghrelease/source.yml
@@ -15,7 +15,6 @@
        extra_args="{{ item.extra_args | default(omit)}}"
       with_items:
          - name: github3.py
-           extra_args: "--pre"
          - name: semver
          - name: uritemplate
       ignore_errors: true


### PR DESCRIPTION
Starting from 11.10.2017 that code fails. Why did we use experimental github3.py anyways?