### PR TITLE
Rework gh_release module

### DIFF
--- a/library/gh_release.py
+++ b/library/gh_release.py
@@ -14,9 +14,6 @@ except ImportError:
     HAS_SEMVER = False
 
 
-METHOD_GET = 'GET'
-
-
 class GithubClient(object):
     API_URL = 'https://api.github.com'
 
@@ -34,14 +31,16 @@ class GithubClient(object):
     def login(self, access_token):
         self.access_token = access_token
 
-    def request(self, method, path):
-        result = open_url(
+    def request(self, path):
+        request = urllib2.Request(
             url=self.API_URL + path,
-            method=method,
             headers=self.get_authorization_header()
         )
 
-        return json.load(result)
+        try:        
+            return json.load(urllib2.urlopen(request))
+        except Exception as e:
+            return None
 
     def download(self, url, dest, headers={}, unredirected_header={}):
         request = urllib2.Request(url)
@@ -67,7 +66,6 @@ class GithubClient(object):
 
     def me(self):
         return self.request(
-            method=METHOD_GET,
             path='/user'
         )
 
@@ -80,23 +78,37 @@ class GithubClient(object):
 
 
 class Repository(object):
+    MAX_RELEASES_IN_REPO = 200
+
     def __init__(self, client, owner, repo):
         self.client = client
         self.owner = owner
         self.repo = repo
 
     def releases(self):
-        releases = self.client.request(
-            method=METHOD_GET,
-            path='/repos/{owner}/{repo}/releases'.format(
-                owner=self.owner,
-                repo=self.repo
-            )
-        )
-
+        current_page = 1
         releases_list = []
-        for release in releases:
-            releases_list.append(ReleaseModel(self.client, release))
+
+        while True:
+            releases = self.client.request(
+                path='/repos/{owner}/{repo}/releases?per_page={max_releases}&page={page}'.format(
+                    owner=self.owner,
+                    repo=self.repo,
+                    max_releases=self.MAX_RELEASES_IN_REPO,
+                    page=current_page
+                )
+            )
+
+            if releases:
+                for release in releases:
+                    releases_list.append(ReleaseModel(self.client, release))
+            else:
+                break
+
+            if len(releases_list) < self.MAX_RELEASES_IN_REPO:
+                current_page = current_page + 1
+            else:
+                break
 
         return releases_list
 
@@ -104,7 +116,6 @@ class Repository(object):
         return ReleaseModel(
             client=self.client,
             data=self.client.request(
-                method=METHOD_GET,
                 path='/repos/{owner}/{repo}/releases/latest'.format(
                     owner=self.owner,
                     repo=self.repo
@@ -116,7 +127,6 @@ class Repository(object):
         return ReleaseModel(
             client=self.client,
             data=self.client.request(
-                method=METHOD_GET,
                 path='/repos/{owner}/{repo}/releases/{id}'.format(
                     owner=self.owner,
                     repo=self.repo,
@@ -129,7 +139,6 @@ class Repository(object):
         return ReleaseModel(
             client=self.client,
             data=self.client.request(
-                method=METHOD_GET,
                 path='/repos/{owner}/{repo}/releases/tags/{tag}'.format(
                     owner=self.owner,
                     repo=self.repo,
@@ -235,6 +244,8 @@ class GithubReleases(object):
             for release in self.repository.releases():
                 if release.tag_name == self.version:
                     return release
+            self.module.fail_json(msg="failed to find draft release {} in repo {}".format(self.version, self.full_repo))
+
         else:
             # Get a specific release not latest
             release_from_tag = self.repository.release_from_tag(self.version)


### PR DESCRIPTION
This PR achieves following:

1. Stop using buggy **open_url** which returns None periodically, and use **urllib2.urlopen** instead
2. **/repos/:owner/:repo/releases** API endpoint uses pagination (https://developer.github.com/v3/guides/traversing-with-pagination/). We should make sure that we requests additional pages by introducing **MAX_RELEASES_IN_REPO** constant. Now this module will fetch releases until it fetched that amount, or until there are no more releases to fetch. Be default I made this value equal 200.

Before these changes, it was impossible to deploy releases older than 10-15 releases ago.