### PR TITLE
Fix deployments without GitHub token

### DIFF
--- a/tasks/resolver/github_releases.yml
+++ b/tasks/resolver/github_releases.yml
@@ -25,9 +25,9 @@
     dest_template="{{ deployment_github_release_dest_template | default(omit) }}"
     version="{{ deployment_version }}"
     release_type="{{ deployment_github_release_type }}"
-    glob="{{ deployment_github_release_glob | default('omit') }}"
+    glob="{{ deployment_github_release_glob | default(omit) }}"
     download_source="{{ deployment_github_release_source | default('None') }}"
-    token="{{ deployment_github_release_token | default('omit') }}"
+    token="{{ deployment_github_release_token | default(omit) }}"
     deployment_overwrite={{ deployment_overwrite }}
   register: gh_releases_output
 


### PR DESCRIPTION
When/if you try to deploy a release of an open-sourced project, in most cases you don't need to have GitHub access token, it should be omitted.
Unfortunately, because of this typo ansible was always using `omit` as GitHub token instead of just skipping it.